### PR TITLE
FAT-Jar mit AppkiationStarter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group 'de.ergodirekt.drag'
-version '1.0-SNAPSHOT'
+version 1.0-SNAPSHOT

--- a/gui/build.gradle
+++ b/gui/build.gradle
@@ -3,8 +3,21 @@ apply plugin: 'idea'
 
 sourceCompatibility = 1.8
 
+
+task fatJar(type: Jar) {
+    manifest {
+        attributes("Implementation-Title": "Dragger",
+                "Implementation-Version": version,
+                "Main-Class": "de.ergodirekt.drag.ApplicationStarter")
+    }
+    baseName = project.name + '-all'
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+}
+
 repositories {
     mavenCentral()
+    flatDir dirs: "${rootDir}/lib"
 }
 
 dependencies {

--- a/gui/src/main/java/de/ergodirekt/drag/ApplicationStarter.java
+++ b/gui/src/main/java/de/ergodirekt/drag/ApplicationStarter.java
@@ -1,0 +1,13 @@
+package de.ergodirekt.drag;
+
+import de.ergodirekt.drag.gui.SendFileGUI;
+
+/**
+ * @author tz
+ */
+public class ApplicationStarter {
+    public static void main(String[] args) {
+        new SendFileGUI();
+        // TODO Hintergrund-Task für den Empfang starten
+    }
+}

--- a/gui/src/main/java/de/ergodirekt/drag/gui/SendFileGUI.java
+++ b/gui/src/main/java/de/ergodirekt/drag/gui/SendFileGUI.java
@@ -134,9 +134,6 @@ public class SendFileGUI {
     }
 
 
-    public static void main(String[] args) {
-        new SendFileGUI();
-    }
 
     private JMenuBar getMenue() {
         JMenuBar bar = new JMenuBar();


### PR DESCRIPTION
Fat-Jat wird mit 
gradle fatJar im GUI-Modul erzeugt.

Ergebnis ist dann eine gui-all-1.0-SNAPSHOT.jar, die mit Doppelklick gestartet werden kann.